### PR TITLE
NSRequiresAquaSystemAppearance=True

### DIFF
--- a/run-mac.spec
+++ b/run-mac.spec
@@ -50,6 +50,6 @@ app = BUNDLE(
         'NSPrincipleClass': 'NSApplication',
         'NSAppleScriptEnabled': False,
         'NSHighResolutionCapable': 'True',
-        'NSRequiresAquaSystemAppearance': 'NO'
+        'NSRequiresAquaSystemAppearance': 'True'
     }
 )


### PR DESCRIPTION
A very simple fix for issue #74 

This should deactivate dark mode altogether for the launcher. Not optimal, but at least user can read the messages.

This follows instructions from Apple to [opt-out of the dark mode](https://developer.apple.com/documentation/appkit/nsappearancecustomization/choosing_a_specific_appearance_for_your_app)

I guess we can come back to this later if necessary.