### PR TITLE
Fixing base64 encoding on lndconnect code

### DIFF
--- a/node_launcher/services/lndconnect.py
+++ b/node_launcher/services/lndconnect.py
@@ -2,6 +2,10 @@ import base64
 import qrcode
 
 
+def base64URL_from_base64(s):
+    return s.replace('+', '-').replace('/', '_').rstrip('=')
+
+
 def get_deprecated_lndconnect_url(host, port, cert_path, macaroon_path):
     return f'lndconnect:?cert={cert_path}&macaroon={macaroon_path}&host={host}:{port}'
 
@@ -11,9 +15,11 @@ def get_lndconnect_url(host, port, cert_path, macaroon_path):
         lines = cert_file.read().split('\n')
         lines = [line for line in lines if line != '']
         cert = ''.join(lines[1:-1])
+        cert = base64URL_from_base64(cert)
 
     with open(macaroon_path, 'rb') as macaroon_file:
         macaroon = base64.b64encode(macaroon_file.read()).decode('ascii')
+        macaroon = base64URL_from_base64(macaroon)
 
     return f'lndconnect://{host}:{port}?cert={cert}&macaroon={macaroon}'
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,5 @@ PyTest
 pytest-qt
 qrcode
 requests
-requests
 webassets
 wtforms


### PR DESCRIPTION
Doing a URL safe encoding of base64 representations of `tls.cert` and `admin.macaroon` files to generate the Zap iOS QRCode.