### PR TITLE
Fix for fail to start when a bitlocker locked drive is present on Windows

### DIFF
--- a/node_launcher/services/hard_drives.py
+++ b/node_launcher/services/hard_drives.py
@@ -26,7 +26,7 @@ class HardDrives(object):
     def get_gb(path: str) -> int:
         try:
             capacity, used, free, percent = psutil.disk_usage(path)
-        except PermissionError:
+        except (PermissionError, OSError):
             return 0
         free_gb = math.floor(free / GIGABYTE)
         return free_gb

--- a/node_launcher/services/hard_drives.py
+++ b/node_launcher/services/hard_drives.py
@@ -26,7 +26,7 @@ class HardDrives(object):
     def get_gb(path: str) -> int:
         try:
             capacity, used, free, percent = psutil.disk_usage(path)
-        except (PermissionError, OSError):
+        except:
             return 0
         free_gb = math.floor(free / GIGABYTE)
         return free_gb


### PR DESCRIPTION
When the node launcher tries to check the disks for space and type it raises this error when it runs into a disk locked with Bitlocker and the launch stops:
OSError: [WinError -2144272384] This drive is locked by BitLocker Drive Encryption. You must unlock this drive from Control Panel

From documentation:
"OSError is raised when a system function returns a system-related error, including I/O failures such as “file not found” or “disk full” (not for illegal argument types or other incidental errors)."

So adding "OSError" to except in get_gb() should skip that disk and continue to the next. Tried it out and it worked for me. Should fix issue #47 and might solve issue #120 and #121 as well as the launch stopped when they ran into the OSError

(I'm not an expert in this area, so if the "OSError" has some other crucial function maybe the except should be specified to the specific error)